### PR TITLE
处理编码等问题

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,6 +6,7 @@ from ncatbot.utils import config, get_log
 import re
 import ast
 import html
+from urllib.parse import quote  # 新增URL编码模块
 
 # ========== 设置配置项 ==========
 config.set_bot_uin("")  # 设置 bot QQ 号 (必填)
@@ -17,7 +18,7 @@ bot = BotClient()
 _log = get_log()
 
 # ========= 定义允许处理消息的群聊 ==========
-allowed_groups = [123456，12345678]  # 根据需要添加群号
+allowed_groups = [123456, 12345678]  # 修正为英文逗号
 
 # ========= 注册群聊消息回调函数 ==========
 @bot.group_event()
@@ -26,7 +27,7 @@ async def on_group_message(msg: GroupMessage):
     raw = html.unescape(msg.raw_message)
     text_content = ""
     
-    # 如果消息内容以 "[{" 开头，则尝试解析为消息链，否则直接使用原始文本
+    # 解析消息内容
     if raw.lstrip().startswith("[{"):
         try:
             parsed = ast.literal_eval(raw)
@@ -57,14 +58,16 @@ async def on_group_message(msg: GroupMessage):
 
     # 仅处理允许的群聊消息
     if msg.group_id in allowed_groups:
-        # 检查是否为维基链接格式 [[关键词]]
+        # 处理维基链接格式 [[关键词]]
         wiki_match = re.search(r'\[\[(.*?)\]\]', text_content)
-        # 检查是否为 Template 格式 {{内容}}
+        # 处理Template格式 {{内容}}
         template_match = re.search(r'\{\{(.*?)\}\}', text_content)
         
         if wiki_match:
             keyword = wiki_match.group(1)
-            wiki_url = f"https://zh.wikipedia.org/wiki/{keyword}"
+            # 对关键词进行URL编码
+            encoded_keyword = quote(keyword, encoding='utf-8')
+            wiki_url = f"https://zh.wikipedia.org/wiki/{encoded_keyword}"
             reply_message = MessageChain([Text(wiki_url)])
             _log.debug({
                 "event": "group_message_reply",
@@ -72,9 +75,12 @@ async def on_group_message(msg: GroupMessage):
                 "reply_message": wiki_url
             })
             await msg.reply(rtf=reply_message)
+            
         elif template_match:
             content = template_match.group(1)
-            template_text = f"https://zh.wikipedia.org/wiki/Template:{content}"
+            # 对模板内容进行URL编码
+            encoded_content = quote(content, encoding='utf-8')
+            template_text = f"https://zh.wikipedia.org/wiki/Template:{encoded_content}"
             reply_message = MessageChain([Text(template_text)])
             _log.debug({
                 "event": "group_message_reply",


### PR DESCRIPTION
1. 添加了urllib.parse.quote用于URL编码
2. 修正了allowed_groups列表中的中文逗号问题
3. 在生成链接时对关键词进行UTF-8编码处理
4. 保持原有消息解析逻辑，仅修改URL生成部分
5. 编码时显式指定encoding=utf-8确保兼容性